### PR TITLE
Fix includeCategoryBitMask type

### DIFF
--- a/SCNTechniqueGlow/NodeTechnique.plist
+++ b/SCNTechniqueGlow/NodeTechnique.plist
@@ -15,7 +15,7 @@
 			<key>metalFragmentShader</key>
 			<string>mask_fragment</string>
 			<key>includeCategoryMask</key>
-			<string>2</string>
+			<integer>2</integer>
 			<key>inputs</key>
 			<dict>
 				<key>colorSampler</key>


### PR DESCRIPTION
according to the [docs](https://developer.apple.com/documentation/scenekit/scntechnique) `includeCategoryBitMask` must be a Number (8-bit unsigned integer)